### PR TITLE
ML notebook hygiene: imports, drop class_weight, remove dead code

### DIFF
--- a/ENEE408N_Traditional_ML_Methods.ipynb
+++ b/ENEE408N_Traditional_ML_Methods.ipynb
@@ -1,6 +1,442 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9blsIpGsQCDU",
+        "outputId": "6a1439ea-83dd-4c9b-9ec5-0d111b0f5c9f"
+      },
+      "source": [
+        "from google.colab import drive\n",
+        "drive.mount('/content/drive')"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Mounted at /content/drive\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": true,
+        "id": "VuuICPAnutyF"
+      },
+      "source": [
+        "!pip install cuml-cu12 --extra-index-url=https://pypi.nvidia.com"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CydOmalxcNSZ"
+      },
+      "source": "import numpy as np\nimport pandas as pd\nimport matplotlib.pyplot as plt\nimport os\nfrom sklearn.neighbors import KNeighborsClassifier\nfrom sklearn.svm import SVC\nfrom sklearn.metrics import (\n    accuracy_score,\n    confusion_matrix,\n    classification_report,\n    roc_auc_score,\n    matthews_corrcoef,\n)\nfrom sklearn.feature_selection import SelectKBest, chi2\nfrom sklearn.preprocessing import StandardScaler, MinMaxScaler\nfrom sklearn.model_selection import (\n    train_test_split,\n    GridSearchCV,\n    StratifiedGroupKFold,\n)\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.decomposition import PCA\nfrom sklearn.discriminant_analysis import LinearDiscriminantAnalysis\nfrom imblearn.over_sampling import RandomOverSampler\nfrom imblearn.pipeline import Pipeline as ImbPipeline\nimport joblib",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "cwkvOrpjQGkk"
+      },
+      "source": [
+        "DIR_PATH = '/content/drive/MyDrive/1. Academics/ENEE408N/ENEE408N Project/sample of DREAMT dataset'\n",
+        "# DIR_PATH = '/data'\n",
+        "TRAIN_PATH = os.path.join(DIR_PATH, 'unbal_all_ppg_feat_extr_train.csv')\n",
+        "TEST_PATH = os.path.join(DIR_PATH, 'unbal_all_ppg_feat_extr_test.csv')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "34jedlFDf2k6"
+      },
+      "source": [
+        "train_df = pd.read_csv(TRAIN_PATH)\n",
+        "test_df = pd.read_csv(TEST_PATH)\n",
+        "\n",
+        "X_train = train_df.drop(['Label'], axis=1)\n",
+        "y_train = train_df['Label']\n",
+        "X_test = test_df.drop(['Label'], axis=1)\n",
+        "y_test = test_df['Label']\n",
+        "\n",
+        "A = sum(y_train)\n",
+        "X = len(y_train)\n",
+        "print(f'Apnea count: {A}/{X} ({100*A/X:.2f}%)')\n",
+        "print(f'Nonapnea count: {X-A}/{X} ({100*(X-A)/X:.2f}%)')\n",
+        "\n",
+        "ros = RandomOverSampler(random_state=42)\n",
+        "X_train, y_train = ros.fit_resample(X_train, y_train)\n",
+        "\n",
+        "A = sum(y_train)\n",
+        "X = len(y_train)\n",
+        "print(f'Apnea count: {A}/{X} ({100*A/X:.2f}%)')\n",
+        "print(f'Nonapnea count: {X-A}/{X} ({100*(X-A)/X:.2f}%)')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5HRaz2iDoO_Q"
+      },
+      "source": [
+        "# ML Models"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dSmr1Ei15WCg"
+      },
+      "source": "def model_pipeline(X_train, y_train, model, scaler=None, dim_reduction=None, name=None):\n  if scaler is None and dim_reduction is None:\n    pipeline = ImbPipeline([\n        (\"model\", model)\n    ])\n  elif scaler is None:\n    pipeline = ImbPipeline([\n        (\"dim_reduction\", dim_reduction),\n        (\"model\", model)\n    ])\n  elif dim_reduction is None:\n    pipeline = ImbPipeline([\n        (\"scaler\", scaler),\n        (\"model\", model)\n    ])\n  else:\n    pipeline = ImbPipeline([\n        (\"scaler\", scaler),\n        (\"dim_reduction\", dim_reduction),\n        (\"model\", model)\n    ])\n\n  pipeline.fit(X_train, y_train)\n\n  if name is not None:\n    joblib.dump(pipeline, os.path.join(DIR_PATH, f'{name}.joblib'))\n\n  return pipeline\n\ndef model_report(pipeline, X_test, y_test, show=False):\n  y_pred = pipeline.predict(X_test)\n\n  metrics = {}\n  metrics['accuracy'] = accuracy_score(y_test, y_pred)\n  metrics['conf_mat'] = confusion_matrix(y_test, y_pred)\n  metrics['classification_rep'] = classification_report(y_test, y_pred)\n\n  if show:\n    print(\"Accuracy:\", metrics['accuracy'])\n    print(\"Confusion matrix:\\n\", metrics['conf_mat'])\n    print(\"Classification report:\\n\", metrics['classification_rep'])\n\n  return metrics",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8-9FX900_vzu"
+      },
+      "source": [
+        "## KNN"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "u81oI3gRjNw7"
+      },
+      "source": [
+        "pipeline = model_pipeline(\n",
+        "    X_train,\n",
+        "    y_train,\n",
+        "    model=KNeighborsClassifier(n_neighbors=3),\n",
+        "    scaler=StandardScaler(),\n",
+        "    name='knn_3'\n",
+        "  )\n",
+        "metrics = model_report(pipeline, X_test, y_test, show=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tV4OJc5dpHuc"
+      },
+      "source": [
+        "KNN + Univariate"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "BbufDfKp63B3"
+      },
+      "source": [
+        "pipeline = model_pipeline(\n",
+        "    X_train,\n",
+        "    y_train,\n",
+        "    model=KNeighborsClassifier(n_neighbors=3),\n",
+        "    scaler=StandardScaler(),\n",
+        "    dim_reduction=SelectKBest(k=5),\n",
+        "    name='knn_3_univariate_5'\n",
+        "  )\n",
+        "metrics = model_report(pipeline, X_test, y_test, show=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d7DTVduB-hvK"
+      },
+      "source": [
+        "KNN + Chi_square"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "feuUKrIz-hdU"
+      },
+      "source": [
+        "pipeline = model_pipeline(\n",
+        "    X_train,\n",
+        "    y_train,\n",
+        "    model=KNeighborsClassifier(n_neighbors=3),\n",
+        "    scaler=MinMaxScaler(),\n",
+        "    dim_reduction=SelectKBest(score_func=chi2, k=5),\n",
+        "    name='knn_3_chi_5'\n",
+        "  )\n",
+        "metrics = model_report(pipeline, X_test, y_test, show=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xu9aL9iW-9-i"
+      },
+      "source": [
+        "KNN + PCA"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XT88_BPE-81T"
+      },
+      "source": [
+        "pipeline = model_pipeline(\n",
+        "    X_train,\n",
+        "    y_train,\n",
+        "    model=KNeighborsClassifier(n_neighbors=3),\n",
+        "    scaler=StandardScaler(),\n",
+        "    dim_reduction=PCA(n_components=3),\n",
+        "    name='knn_3_pca_3'\n",
+        "  )\n",
+        "metrics = model_report(pipeline, X_test, y_test, show=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eAn4xElZ_Bag"
+      },
+      "source": [
+        "KNN + LDA"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Zz4y4k54_CZq"
+      },
+      "source": [
+        "pipeline = model_pipeline(\n",
+        "    X_train,\n",
+        "    y_train,\n",
+        "    model=KNeighborsClassifier(n_neighbors=3),\n",
+        "    scaler=StandardScaler(),\n",
+        "    dim_reduction=LinearDiscriminantAnalysis(n_components=1),\n",
+        "    name='knn_3_lda_1'\n",
+        "  )\n",
+        "metrics = model_report(pipeline, X_test, y_test, show=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "l9MmkP_LpLio"
+      },
+      "source": [
+        "## RF"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fhxvRXjd_2-A"
+      },
+      "source": [
+        "RF + Univariate"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vz5_sXLK_1hR"
+      },
+      "source": "rf = RandomForestClassifier(\n    n_estimators=100,\n    random_state=42,\n    max_depth=None,\n    min_samples_leaf=5\n)\npipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=rf,\n    scaler=StandardScaler(),\n    dim_reduction=SelectKBest(k=5),\n    name='rf_100w_univariate_5'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yL_vrx3sRp8P"
+      },
+      "source": [
+        "RF + chi"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jkGH_M1yRpbn",
+        "collapsed": true
+      },
+      "source": "rf = RandomForestClassifier(\n    n_estimators=100,\n    random_state=42,\n    max_depth=None,\n    min_samples_leaf=5\n)\npipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=rf,\n    scaler=MinMaxScaler(),\n    dim_reduction=SelectKBest(score_func=chi2, k=5),\n    name='rf_100w_chi_5'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "inrqEmiORr9y"
+      },
+      "source": [
+        "RF + PCA"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "rK-IlwDrRltQ"
+      },
+      "source": "rf = RandomForestClassifier(\n    n_estimators=100,\n    random_state=42,\n    max_depth=None,\n    min_samples_leaf=5\n)\npipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=rf,\n    scaler=StandardScaler(),\n    dim_reduction=PCA(n_components=3),\n    name='rf_100w_pca_3'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZYxoXmBBRtKj"
+      },
+      "source": [
+        "RF + LDA"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TZasbbMtRvDJ"
+      },
+      "source": "rf = RandomForestClassifier(\n    n_estimators=100,\n    random_state=42,\n    max_depth=None,\n    min_samples_leaf=5\n)\npipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=rf,\n    scaler=StandardScaler(),\n    dim_reduction=LinearDiscriminantAnalysis(n_components=1),\n    name='rf_100w_lda_1'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oncR6n24Bgjy"
+      },
+      "source": [
+        "import os\n",
+        "# Check it exists and see its size\n",
+        "path = os.path.join(DIR_PATH, 'rf_100w_lda_1.joblib')\n",
+        "print(os.path.exists(path))        # should be True\n",
+        "print(os.path.getsize(path), \"bytes\")\n",
+        "\n",
+        "# Download\n",
+        "from google.colab import files\n",
+        "files.download(path)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6j1JWm_SodNp"
+      },
+      "source": [
+        "## SVM"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZBhgY-ioSlZC"
+      },
+      "source": [
+        "SVM + univariate"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "QAa8MVQDSneg"
+      },
+      "source": "pipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=SVC(kernel='rbf'),\n    scaler=StandardScaler(),\n    dim_reduction=SelectKBest(k=5),\n    name='svm_rbf_univariate_5'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v6mgxGJFSpix"
+      },
+      "source": [
+        "SVM + chi2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3PnlcCO2SrF1"
+      },
+      "source": "pipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=SVC(kernel='rbf'),\n    scaler=MinMaxScaler(),\n    dim_reduction=SelectKBest(score_func=chi2, k=5),\n    name='svm_rbf_chi_5'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pousOri_SrXO"
+      },
+      "source": [
+        "SVM + PCA"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "tqkonNWnStCt"
+      },
+      "source": "pipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=SVC(kernel='rbf'),\n    scaler=StandardScaler(),\n    dim_reduction=PCA(n_components=3),\n    name='svm_rbf_pca_3'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rmoalByrSsr-"
+      },
+      "source": [
+        "SVM + LDA"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xttcp1ktSusW"
+      },
+      "source": "pipeline = model_pipeline(\n    X_train,\n    y_train,\n    model=SVC(kernel='rbf'),\n    scaler=StandardScaler(),\n    dim_reduction=LinearDiscriminantAnalysis(n_components=1),\n    name='svm_rbf_lda_1'\n  )\nmetrics = model_report(pipeline, X_test, y_test, show=True)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rr_DfuGNSvyN"
+      },
+      "source": [
+        "# Feedforward Neural Net"
+      ]
+    }
+  ],
   "metadata": {
     "colab": {
       "provenance": [],
@@ -15,886 +451,6 @@
     },
     "accelerator": "GPU"
   },
-  "cells": [
-    {
-      "cell_type": "code",
-      "source": [
-        "from google.colab import drive\n",
-        "drive.mount('/content/drive')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9blsIpGsQCDU",
-        "outputId": "6a1439ea-83dd-4c9b-9ec5-0d111b0f5c9f"
-      },
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Mounted at /content/drive\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install cuml-cu12 --extra-index-url=https://pypi.nvidia.com"
-      ],
-      "metadata": {
-        "collapsed": true,
-        "id": "VuuICPAnutyF"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CydOmalxcNSZ"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import matplotlib.pyplot as plt\n",
-        "import os\n",
-        "from sklearn.neighbors import KNeighborsClassifier\n",
-        "from sklearn.metrics import accuracy_score, confusion_matrix, classification_report\n",
-        "from sklearn.feature_selection import SelectKBest, chi2\n",
-        "from sklearn.preprocessing import StandardScaler, MinMaxScaler\n",
-        "from sklearn.model_selection import train_test_split\n",
-        "from sklearn.ensemble import RandomForestClassifier\n",
-        "from sklearn.decomposition import PCA\n",
-        "from sklearn.discriminant_analysis import LinearDiscriminantAnalysis\n",
-        "# from cuml.svm import SVC\n",
-        "from imblearn.over_sampling import RandomOverSampler\n",
-        "from sklearn.pipeline import Pipeline\n",
-        "import joblib"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "DIR_PATH = '/content/drive/MyDrive/1. Academics/ENEE408N/ENEE408N Project/sample of DREAMT dataset'\n",
-        "# DIR_PATH = '/data'\n",
-        "TRAIN_PATH = os.path.join(DIR_PATH, 'unbal_all_ppg_feat_extr_train.csv')\n",
-        "TEST_PATH = os.path.join(DIR_PATH, 'unbal_all_ppg_feat_extr_test.csv')"
-      ],
-      "metadata": {
-        "id": "cwkvOrpjQGkk"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "train_df = pd.read_csv(TRAIN_PATH)\n",
-        "test_df = pd.read_csv(TEST_PATH)\n",
-        "\n",
-        "X_train = train_df.drop(['Label'], axis=1)\n",
-        "y_train = train_df['Label']\n",
-        "X_test = test_df.drop(['Label'], axis=1)\n",
-        "y_test = test_df['Label']\n",
-        "\n",
-        "A = sum(y_train)\n",
-        "X = len(y_train)\n",
-        "print(f'Apnea count: {A}/{X} ({100*A/X:.2f}%)')\n",
-        "print(f'Nonapnea count: {X-A}/{X} ({100*(X-A)/X:.2f}%)')\n",
-        "weightN = int(X/(X-A))\n",
-        "weightA = int(X/A)\n",
-        "print(f'weights: N {weightN}, A {weightA}')\n",
-        "\n",
-        "ros = RandomOverSampler(random_state=42)\n",
-        "\n",
-        "X_train, y_train = ros.fit_resample(X_train, y_train)\n",
-        "\n",
-        "A = sum(y_train)\n",
-        "X = len(y_train)\n",
-        "print(f'Apnea count: {A}/{X} ({100*A/X:.2f}%)')\n",
-        "print(f'Nonapnea count: {X-A}/{X} ({100*(X-A)/X:.2f}%)')"
-      ],
-      "metadata": {
-        "id": "34jedlFDf2k6"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Class Balancing\n",
-        "\n",
-        "$A = \\text{# Apnea}$\n",
-        "\n",
-        "$N = \\text{# Non-apnea}$\n",
-        "\n",
-        "$X = \\text{# Total}$\n",
-        "\n",
-        "$a = \\text{Factor by which to oversample A}$\n",
-        "\n",
-        "$n = \\text{Factor by which to oversample N}$\n",
-        "\n",
-        "$d = \\text{Factor by which to reduce the overall training set size}$\n",
-        "\n",
-        "$A+N=X$\n",
-        "\n",
-        "$aA+nN=\\frac{X}{d}$\n",
-        "\n",
-        "$aA=nN$\n",
-        "\n",
-        "Solve:\n",
-        "\n",
-        "$a = \\frac{X}{2Ad}$\n",
-        "\n",
-        "$n = \\frac{X}{2Nd}$\n",
-        "\n",
-        "The class weightings will be...\n"
-      ],
-      "metadata": {
-        "id": "TjObFWnPQuZw"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# A = sum(y_train)\n",
-        "# X = len(y_train)\n",
-        "# N = X - A\n",
-        "\n",
-        "# d = 2\n",
-        "\n",
-        "# a = X/(2*A*d)\n",
-        "# n = X/(2*N*d)\n",
-        "\n",
-        "# print(f'Apnea count: {A}/{X} ({100*A/X:.2f}%)')\n",
-        "# print(f'Nonapnea count: {X-A}/{X} ({100*(X-A)/X:.2f}%)')\n",
-        "\n",
-        "# print(f'a = {a}')\n",
-        "# print(f'n = {n}')\n",
-        "# print(f'X/d = {X/d}')"
-      ],
-      "metadata": {
-        "id": "NQy8ca2RQt7M"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# ros = RandomOverSampler(random_state=42)\n",
-        "\n",
-        "# X_res, y_res = ros.fit_resample(X_train, y_train)"
-      ],
-      "metadata": {
-        "id": "1L0_Oz3rYwFr"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "Nuj5Qu2n5Lta"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# DIMENSIONALITY REDUCTION"
-      ],
-      "metadata": {
-        "id": "6VZCSfPioHGK"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "No Dimensionality Reduction"
-      ],
-      "metadata": {
-        "id": "eyyJ3WJznx-j"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# X_train_sel = X_train_scaled\n",
-        "# X_test_sel = X_test_scaled"
-      ],
-      "metadata": {
-        "id": "muty03apn1yq"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Selected Columns"
-      ],
-      "metadata": {
-        "id": "8jyEqGpU69Lh"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Univariate Feature Selection"
-      ],
-      "metadata": {
-        "id": "16dezGppfTEm"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# selector = SelectKBest(k=5)\n",
-        "# X_train_sel = selector.fit_transform(X_train_scaled, y_train)\n",
-        "# selected_cols = X_train.columns[selector.get_support(indices=True)]\n",
-        "# X_test_sel = X_test[selected_cols]\n",
-        "# print(selected_cols)"
-      ],
-      "metadata": {
-        "id": "J7Y0VNhue2qt"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Chi-square"
-      ],
-      "metadata": {
-        "id": "3Vz72ABSkvWr"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# mm_scaler = MinMaxScaler()\n",
-        "# X_train_scaled_mm = mm_scaler.fit_transform(X_train)\n",
-        "# X_test_scaled_mm = mm_scaler.transform(X_test)\n",
-        "# selector = SelectKBest(score_func=chi2, k=10)\n",
-        "# X_train_sel = selector.fit_transform(X_train_scaled_mm, y_train)\n",
-        "# X_test_sel = selector.transform(X_test_scaled_mm)"
-      ],
-      "metadata": {
-        "id": "mWngv3D6krXr"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "PCA"
-      ],
-      "metadata": {
-        "id": "uybo0kLrfR8l"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# NUM_COMPONENTS = 3\n",
-        "# pca = PCA(n_components=NUM_COMPONENTS)\n",
-        "# X_train_sel = pca.fit_transform(X_train_scaled)\n",
-        "# X_test_sel = pca.transform(X_test_scaled)\n",
-        "\n",
-        "# plt.scatter(X_train_sel[:, 0], X_train_sel[:, 1], c=y_train)\n",
-        "# plt.xlabel(\"PC1\")\n",
-        "# plt.ylabel(\"PC2\")\n",
-        "# plt.title(\"PCA (2 Components)\")\n",
-        "# plt.show()"
-      ],
-      "metadata": {
-        "id": "6ABFFEh_fQH1"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "LDA"
-      ],
-      "metadata": {
-        "id": "YTNZ4vwgk1fG"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# lda = LinearDiscriminantAnalysis(n_components=1)\n",
-        "# X_train_sel = lda.fit_transform(X_train_scaled, y_train)\n",
-        "# X_test_sel = lda.transform(X_test_scaled)"
-      ],
-      "metadata": {
-        "id": "6tx9wj2Hk2SN"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# ML Models"
-      ],
-      "metadata": {
-        "id": "5HRaz2iDoO_Q"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def model_pipeline(X_train, y_train, model, scaler=None, dim_reduction=None, name=None):\n",
-        "  if scaler is None and dim_reduction is None:\n",
-        "    pipeline = Pipeline([\n",
-        "        (\"model\", model)\n",
-        "    ])\n",
-        "  elif scaler is None:\n",
-        "    pipeline = Pipeline([\n",
-        "        (\"dim_reduction\", dim_reduction),\n",
-        "        (\"model\", model)\n",
-        "    ])\n",
-        "  elif dim_reduction is None:\n",
-        "    pipeline = Pipeline([\n",
-        "        (\"scaler\", scaler),\n",
-        "        (\"model\", model)\n",
-        "    ])\n",
-        "  else:\n",
-        "    pipeline = Pipeline([\n",
-        "        (\"scaler\", scaler),\n",
-        "        (\"dim_reduction\", dim_reduction),\n",
-        "        (\"model\", model)\n",
-        "    ])\n",
-        "\n",
-        "  pipeline.fit(X_train, y_train)\n",
-        "\n",
-        "  if name is not None:\n",
-        "    joblib.dump(pipeline, os.path.join(DIR_PATH, f'{name}.joblib'))\n",
-        "\n",
-        "  return pipeline\n",
-        "\n",
-        "def model_report(pipeline, X_test, y_test, show=False):\n",
-        "  y_pred = pipeline.predict(X_test)\n",
-        "\n",
-        "  metrics = {}\n",
-        "  metrics['accuracy'] = accuracy_score(y_test, y_pred)\n",
-        "  metrics['conf_mat'] = confusion_matrix(y_test, y_pred)\n",
-        "  metrics['classification_rep'] = classification_report(y_test, y_pred)\n",
-        "\n",
-        "  if show:\n",
-        "    print(\"Accuracy:\", metrics['accuracy'])\n",
-        "    print(\"Confusion matrix:\\n\", metrics['conf_mat'])\n",
-        "    print(\"Classification report:\\n\", metrics['classification_rep'])\n",
-        "\n",
-        "  return metrics"
-      ],
-      "metadata": {
-        "id": "dSmr1Ei15WCg"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## KNN"
-      ],
-      "metadata": {
-        "id": "8-9FX900_vzu"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=KNeighborsClassifier(n_neighbors=3),\n",
-        "    scaler=StandardScaler(),\n",
-        "    name='knn_3'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "u81oI3gRjNw7"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "KNN + Univariate"
-      ],
-      "metadata": {
-        "id": "tV4OJc5dpHuc"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=KNeighborsClassifier(n_neighbors=3),\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=SelectKBest(k=5),\n",
-        "    name='knn_3_univariate_5'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "BbufDfKp63B3"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "KNN + Chi_square"
-      ],
-      "metadata": {
-        "id": "d7DTVduB-hvK"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=KNeighborsClassifier(n_neighbors=3),\n",
-        "    scaler=MinMaxScaler(),\n",
-        "    dim_reduction=SelectKBest(score_func=chi2, k=5),\n",
-        "    name='knn_3_chi_5'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "feuUKrIz-hdU"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "KNN + PCA"
-      ],
-      "metadata": {
-        "id": "xu9aL9iW-9-i"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=KNeighborsClassifier(n_neighbors=3),\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=PCA(n_components=3),\n",
-        "    name='knn_3_pca_3'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "XT88_BPE-81T"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "KNN + LDA"
-      ],
-      "metadata": {
-        "id": "eAn4xElZ_Bag"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=KNeighborsClassifier(n_neighbors=3),\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=LinearDiscriminantAnalysis(n_components=1),\n",
-        "    name='knn_3_lda_1'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "Zz4y4k54_CZq"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## RF"
-      ],
-      "metadata": {
-        "id": "l9MmkP_LpLio"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "RF + Univariate"
-      ],
-      "metadata": {
-        "id": "fhxvRXjd_2-A"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "rf = RandomForestClassifier(\n",
-        "    n_estimators=100,\n",
-        "    random_state=42,\n",
-        "    class_weight={0: weightN, 1:weightA},\n",
-        "    max_depth=None,\n",
-        "    min_samples_leaf=5\n",
-        ")\n",
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=rf,\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=SelectKBest(k=5),\n",
-        "    name='rf_100w_univariate_5'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "vz5_sXLK_1hR"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "RF + chi"
-      ],
-      "metadata": {
-        "id": "yL_vrx3sRp8P"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "rf = RandomForestClassifier(\n",
-        "    n_estimators=100,\n",
-        "    random_state=42,\n",
-        "    class_weight={0: weightN, 1:weightA},\n",
-        "    max_depth=None,\n",
-        "    min_samples_leaf=5\n",
-        ")\n",
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=rf,\n",
-        "    scaler=MinMaxScaler(),\n",
-        "    dim_reduction=SelectKBest(score_func=chi2, k=5),\n",
-        "    name='rf_100w_chi_5'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "jkGH_M1yRpbn",
-        "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "RF + PCA"
-      ],
-      "metadata": {
-        "id": "inrqEmiORr9y"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "rf = RandomForestClassifier(\n",
-        "    n_estimators=100,\n",
-        "    random_state=42,\n",
-        "    class_weight={0: weightN, 1:weightA},\n",
-        "    max_depth=None,\n",
-        "    min_samples_leaf=5\n",
-        ")\n",
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=rf,\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=PCA(n_components=3),\n",
-        "    name='rf_100w_pca_3'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "rK-IlwDrRltQ"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "RF + LDA"
-      ],
-      "metadata": {
-        "id": "ZYxoXmBBRtKj"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "rf = RandomForestClassifier(\n",
-        "    n_estimators=100,\n",
-        "    random_state=42,\n",
-        "    class_weight={0: weightN, 1:weightA},\n",
-        "    max_depth=None,\n",
-        "    min_samples_leaf=5\n",
-        ")\n",
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=rf,\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=LinearDiscriminantAnalysis(n_components=1),\n",
-        "    name='rf_100w_lda_1'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "TZasbbMtRvDJ"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import os\n",
-        "# Check it exists and see its size\n",
-        "path = os.path.join(DIR_PATH, 'rf_100w_lda_1.joblib')\n",
-        "print(os.path.exists(path))        # should be True\n",
-        "print(os.path.getsize(path), \"bytes\")\n",
-        "\n",
-        "# Download\n",
-        "from google.colab import files\n",
-        "files.download(path)"
-      ],
-      "metadata": {
-        "id": "oncR6n24Bgjy"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## SVM"
-      ],
-      "metadata": {
-        "id": "6j1JWm_SodNp"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "SVM + univariate"
-      ],
-      "metadata": {
-        "id": "ZBhgY-ioSlZC"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=SVC(kernel='rbf'),# class_weight={0: weightN, 1:weightA}),\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=SelectKBest(k=5),\n",
-        "    name='svm_rbf_univariate_5'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "QAa8MVQDSneg"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "SVM + chi2"
-      ],
-      "metadata": {
-        "id": "v6mgxGJFSpix"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=SVC(kernel='rbf'),# class_weight={0: weightN, 1:weightA}),\n",
-        "    scaler=MinMaxScaler(),\n",
-        "    dim_reduction=SelectKBest(score_func=chi2, k=5),\n",
-        "    name='svm_rbf_chi_5'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "3PnlcCO2SrF1"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "SVM + PCA"
-      ],
-      "metadata": {
-        "id": "pousOri_SrXO"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=SVC(kernel='rbf'),#, class_weight={0: weightN, 1:weightA}),\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=PCA(n_components=3),\n",
-        "    name='svm_rbf_pca_3'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "tqkonNWnStCt"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "SVM + LDA"
-      ],
-      "metadata": {
-        "id": "rmoalByrSsr-"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pipeline = model_pipeline(\n",
-        "    X_train,\n",
-        "    y_train,\n",
-        "    model=SVC(kernel='rbf'),# class_weight={0: weightN, 1:weightA}),\n",
-        "    scaler=StandardScaler(),\n",
-        "    dim_reduction=LinearDiscriminantAnalysis(n_components=1),\n",
-        "    name='svm_rbf_lda_1'\n",
-        "  )\n",
-        "metrics = model_report(pipeline, X_test, y_test, show=True)"
-      ],
-      "metadata": {
-        "id": "xttcp1ktSusW"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Feedforward Neural Net"
-      ],
-      "metadata": {
-        "id": "rr_DfuGNSvyN"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "T8sXVFIbSvZK"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "\n",
-        "# rf.fit(X_train_sel, y_train)\n",
-        "# y_pred = rf.predict(X_test_sel)\n",
-        "\n",
-        "# accuracy = accuracy_score(y_test, y_pred)\n",
-        "# conf_mat = confusion_matrix(y_test, y_pred)\n",
-        "# classification_rep = classification_report(y_test, y_pred)\n",
-        "# print(\"Accuracy:\", accuracy)\n",
-        "# print(\"Confusion matrix:\\n\", conf_mat)\n",
-        "# print(\"Classification report:\\n\", classification_rep)"
-      ],
-      "metadata": {
-        "id": "Cx_ExkwPo6KE"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# svm = SVC(kernel='rbf')\n",
-        "# svm.fit(X_train_sel, y_train)\n",
-        "# y_pred = svm.predict(X_test_sel)\n",
-        "\n",
-        "# accuracy = accuracy_score(y_test, y_pred)\n",
-        "# conf_mat = confusion_matrix(y_test, y_pred)\n",
-        "# classification_rep = classification_report(y_test, y_pred)\n",
-        "# print(\"Accuracy:\", accuracy)\n",
-        "# print(\"Confusion matrix:\\n\", conf_mat)\n",
-        "# print(\"Classification report:\\n\", classification_rep)"
-      ],
-      "metadata": {
-        "id": "v8jWPW8cod9d"
-      },
-      "execution_count": null,
-      "outputs": []
-    }
-  ]
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2.

Non-breaking cleanup pass on `ENEE408N_Traditional_ML_Methods.ipynb`. Existing global-oversampling flow is preserved.

## Changes

- **Imports.** Replaced the imports cell with a consolidated block that adds the missing symbols required by later cells and the upcoming pipeline refactor:
  - `from sklearn.svm import SVC`
  - `from sklearn.metrics import roc_auc_score, matthews_corrcoef` (alongside the existing accuracy/conf-mat/classification report)
  - `from sklearn.model_selection import GridSearchCV, StratifiedGroupKFold` (alongside the existing `train_test_split`)
  - Swapped `from sklearn.pipeline import Pipeline` for `from imblearn.pipeline import Pipeline as ImbPipeline`. The `model_pipeline` helper now builds `ImbPipeline(...)` so future per-fold resampling steps can be injected without breaking the helper signature.
- **Class-weight removal.** Stripped `class_weight={0: weightN, 1: weightA}` from every `RandomForestClassifier(...)` instantiation in the RF + Univariate / chi / PCA / LDA cells. Also dropped the now-unused `weightN` / `weightA` computation in the data-load cell. SVM cells already had `class_weight` commented out; cleaned up the trailing comment + dangling parenthesis so the lines are plain `model=SVC(kernel='rbf'),`.
- **Dead code removal.** Deleted:
  - the `# Class Balancing` markdown formula block + the commented-out `a/n/d` math scratch cell
  - the commented-out duplicate `RandomOverSampler` cell
  - the `# DIMENSIONALITY REDUCTION` / `No Dimensionality Reduction` / `Selected Columns` / `Univariate Feature Selection` / `Chi-square` / `PCA` / `LDA` markdown headers and their associated commented-out scratch code cells (these all referenced non-existent `X_train_scaled` etc. and were superseded by the `model_pipeline` helper)
  - empty cells and the trailing commented-out RF/SVM `.fit` scratch at the end of the notebook

## Acceptance criteria

- [x] Add imports: `SVC`, `roc_auc_score`, `matthews_corrcoef`, `GridSearchCV`, `StratifiedGroupKFold`, `ImbPipeline` (replacing existing `sklearn.pipeline.Pipeline`)
- [x] Remove `class_weight='balanced'` / `class_weight={...}` from every `RandomForestClassifier` instantiation
- [x] Delete dead cells: class-balancing math scratch, commented-out oversampling variants, "No Dim Reduction" sections
- [x] Notebook parses as valid nbformat 4; `ast.parse` succeeds on every code cell
- [x] `SVC` references no longer raise `NameError` (now imported at top)

## Verification

- `nbformat.validate` passes (37 cells, down from 56).
- All code cells `ast.parse` successfully.
- No remaining `class_weight` references in the notebook.
- `weightN` / `weightA` are no longer defined or referenced anywhere.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9e6de25-629d-4174-88a3-c8196f1c6237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9e6de25-629d-4174-88a3-c8196f1c6237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

